### PR TITLE
Temporarily disable fragment check

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -26,5 +26,4 @@ jobs:
     - name: Check doc links
       run: |
         cargo install cargo-deadlinks
-        cargo doc
-        cargo deadlinks
+        cargo deadlinks --ignore-fragments


### PR DESCRIPTION
Should be revisited if https://github.com/deadlinks/cargo-deadlinks/issues/120 is fixed