### PR TITLE
Add ChangeTextStyle token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 
 ## Added:
 
+ * [#130] `ChangeTextStyle` token
  * [#114] Added experimental plugin support via the `plugin` Cargo feature. Plugin can be used to modify `TextBox` behaviour.
 
 ## Changed:
@@ -16,6 +17,7 @@ Unreleased
 
 [#114]: https://github.com/embedded-graphics/embedded-text/pull/114
 [#125]: https://github.com/embedded-graphics/embedded-text/pull/125
+[#130]: https://github.com/embedded-graphics/embedded-text/pull/130
 
 0.5.0-beta.1 (2021-06-04)
 ==========================

--- a/examples/plugin.rs
+++ b/examples/plugin.rs
@@ -72,8 +72,8 @@ where
 
     fn next_token(
         &mut self,
-        mut next_token: impl FnMut() -> Option<Token<'a>>,
-    ) -> Option<Token<'a>> {
+        mut next_token: impl FnMut() -> Option<Token<'a, C>>,
+    ) -> Option<Token<'a, C>> {
         if self.last_line {
             return None;
         }
@@ -97,7 +97,7 @@ where
         }
     }
 
-    fn render_token(&mut self, token: Token<'a>) -> Option<Token<'a>> {
+    fn render_token(&mut self, token: Token<'a, C>) -> Option<Token<'a, C>> {
         if self.measured <= self.characters {
             self.rendered = self.measured;
             return Some(token);

--- a/src/alignment/mod.rs
+++ b/src/alignment/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     TextBox,
 };
 use az::SaturatingAs;
-use embedded_graphics::{prelude::Dimensions, text::renderer::TextRenderer};
+use embedded_graphics::{pixelcolor::Rgb888, prelude::Dimensions, text::renderer::TextRenderer};
 
 #[cfg(test)]
 mod test;
@@ -97,6 +97,7 @@ impl VerticalAlignment {
     ) where
         S: TextRenderer,
         M: Plugin<'a, S::Color>,
+        S::Color: From<Rgb888>,
     {
         let text_height = styled_text_box
             .style

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,11 +124,12 @@ use crate::{
 };
 use embedded_graphics::{
     geometry::{Dimensions, Point},
+    pixelcolor::Rgb888,
     primitives::Rectangle,
     text::renderer::{CharacterStyle, TextRenderer},
     transform::Transform,
 };
-pub use parser::Token;
+pub use parser::{ChangeTextStyle, Token};
 
 /// A text box object.
 ///
@@ -169,6 +170,7 @@ where
 
 impl<'a, S> TextBox<'a, S, NoPlugin<<S as TextRenderer>::Color>>
 where
+    <S as TextRenderer>::Color: From<Rgb888>,
     S: TextRenderer + CharacterStyle,
 {
     /// Creates a new `TextBox` instance with a given bounding `Rectangle`.
@@ -295,6 +297,7 @@ impl<'a, S, M> TextBox<'a, S, M>
 where
     S: TextRenderer,
     M: Plugin<'a, S::Color>,
+    S::Color: From<Rgb888>,
 {
     /// Sets the height of the [`TextBox`] to the height of the text.
     #[inline]

--- a/src/rendering/ansi.rs
+++ b/src/rendering/ansi.rs
@@ -1,6 +1,8 @@
 //! ANSI escape sequence related types and functions.
 
-use embedded_graphics::pixelcolor::Rgb888;
+use embedded_graphics::{pixelcolor::Rgb888, prelude::PixelColor, text::DecorationColor};
+
+use crate::parser::ChangeTextStyle;
 
 /// List of supported SGR (Select Graphics Rendition) sequences
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -31,6 +33,22 @@ pub enum Sgr {
 
     /// Reset the background color to transparent
     DefaultBackgroundColor,
+}
+
+impl<C: PixelColor + From<Rgb888>> From<Sgr> for ChangeTextStyle<C> {
+    fn from(sgr: Sgr) -> Self {
+        match sgr {
+            Sgr::Reset => ChangeTextStyle::Reset,
+            Sgr::Underline => ChangeTextStyle::Underline(DecorationColor::TextColor),
+            Sgr::CrossedOut => ChangeTextStyle::Strikethrough(DecorationColor::TextColor),
+            Sgr::UnderlineOff => ChangeTextStyle::Underline(DecorationColor::None),
+            Sgr::NotCrossedOut => ChangeTextStyle::Strikethrough(DecorationColor::None),
+            Sgr::ChangeTextColor(c) => ChangeTextStyle::TextColor(Some(c.into())),
+            Sgr::DefaultTextColor => ChangeTextStyle::TextColor(None),
+            Sgr::ChangeBackgroundColor(c) => ChangeTextStyle::BackgroundColor(Some(c.into())),
+            Sgr::DefaultBackgroundColor => ChangeTextStyle::BackgroundColor(None),
+        }
+    }
 }
 
 fn try_parse_8b_color(v: &[u8]) -> Option<Rgb888> {

--- a/src/style/height_mode.rs
+++ b/src/style/height_mode.rs
@@ -7,7 +7,7 @@
 //! [`TextBox`]: ../../struct.TextBox.html
 use crate::{plugin::Plugin, rendering::cursor::Cursor, style::VerticalOverdraw, TextBox};
 use core::ops::Range;
-use embedded_graphics::{geometry::Dimensions, text::renderer::TextRenderer};
+use embedded_graphics::{geometry::Dimensions, pixelcolor::Rgb888, text::renderer::TextRenderer};
 
 /// Specifies how the [`TextBox`]'s height should be adjusted.
 ///
@@ -200,6 +200,7 @@ impl HeightMode {
     where
         F: TextRenderer,
         M: Plugin<'a, F::Color>,
+        F::Color: From<Rgb888>,
     {
         match self {
             HeightMode::Exact(_) => {}

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -153,7 +153,10 @@ use crate::{
     utils::str_width,
 };
 use az::SaturatingAs;
-use embedded_graphics::text::{renderer::TextRenderer, LineHeight};
+use embedded_graphics::{
+    pixelcolor::Rgb888,
+    text::{renderer::TextRenderer, LineHeight},
+};
 
 pub use self::{
     builder::TextBoxStyleBuilder, height_mode::HeightMode, vertical_overdraw::VerticalOverdraw,
@@ -283,6 +286,7 @@ struct MeasureLineElementHandler<'a, S> {
 
 impl<'a, S: TextRenderer> ElementHandler for MeasureLineElementHandler<'a, S> {
     type Error = Infallible;
+    type Color = S::Color;
 
     fn measure(&self, st: &str) -> u32 {
         str_width(self.style, st)
@@ -329,12 +333,13 @@ impl TextBoxStyle {
         &self,
         plugin: &PluginWrapper<'a, M, S::Color>,
         character_style: &S,
-        parser: &mut Parser<'a>,
+        parser: &mut Parser<'a, S::Color>,
         max_line_width: u32,
     ) -> LineMeasurement
     where
         S: TextRenderer,
         M: Plugin<'a, S::Color>,
+        S::Color: From<Rgb888>,
     {
         let cursor = LineCursor::new(max_line_width, self.tab_size.into_pixels(character_style));
 
@@ -405,6 +410,7 @@ impl TextBoxStyle {
     pub fn measure_text_height<S>(&self, character_style: &S, text: &str, max_width: u32) -> u32
     where
         S: TextRenderer,
+        S::Color: From<Rgb888>,
     {
         let plugin = PluginWrapper::new(NoPlugin::new());
         self.measure_text_height_impl(plugin, character_style, text, max_width)
@@ -420,6 +426,7 @@ impl TextBoxStyle {
     where
         S: TextRenderer,
         M: Plugin<'a, S::Color>,
+        S::Color: From<Rgb888>,
     {
         let mut parser = Parser::parse(text);
         let mut closed_paragraphs: u32 = 0;


### PR DESCRIPTION
This PR adds a new token type to allow plugins to change text style without manually assembling ANSI sequence tokens.