### PR TITLE
Update editor example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Unreleased
  * [#135] Allow using the built-in plugins without the `plugin` feature.
  * [#137] Allow using multiple plugins.
  * [#136] `Cursor` is now public.
+ * [#136] Added `TextBox::take_plugins()`.
 
 ## Changed:
 
  * **breaking** [#133] `TextBoxStyle` and `TextBoxStyleBuilder` no longer implement the `Default` trait.
+ * [#136] Replaced `TextBoxProperties::box_height` with  in `TextBoxProperties::bounding_box`.
+ * [#136] Reworked the editor example to support vertical cursor movement and mouse input.
 
 ## Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
  * [#134] `Tail` plugin
  * [#135] Allow using the built-in plugins without the `plugin` feature.
  * [#137] Allow using multiple plugins.
+ * [#136] `Cursor` is now public.
 
 ## Changed:
 
@@ -26,6 +27,7 @@ Unreleased
 [#133]: https://github.com/embedded-graphics/embedded-text/pull/133
 [#134]: https://github.com/embedded-graphics/embedded-text/pull/134
 [#135]: https://github.com/embedded-graphics/embedded-text/pull/135
+[#136]: https://github.com/embedded-graphics/embedded-text/pull/136
 [#137]: https://github.com/embedded-graphics/embedded-text/pull/137
 [#140]: https://github.com/embedded-graphics/embedded-text/pull/140
 

--- a/examples/interactive-editor.rs
+++ b/examples/interactive-editor.rs
@@ -289,7 +289,7 @@ impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<'_, C> {
             .max(props.box_height - props.text_height)
             .min(0);
 
-        cursor.y = self.vertical_offset;
+        cursor.y += self.vertical_offset;
 
         if let DesiredPosition::Coordinates(pos) = self.desired_cursor_position {
             self.desired_cursor_position =

--- a/examples/interactive-editor.rs
+++ b/examples/interactive-editor.rs
@@ -4,6 +4,7 @@
 //!
 //! The demo uses the "Scrolling" vertical layout which is especially useful for
 //! editor type applications.
+use az::SaturatingAs;
 use embedded_graphics::{
     geometry::AnchorPoint,
     mono_font::{iso_8859_2::FONT_6X10, MonoTextStyleBuilder},
@@ -274,19 +275,21 @@ impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<'_, C> {
         let cursor_coordinates = self.to_screen_space(cursor_coordinates);
 
         // TODO what if the text box is not at 0,0?
+        // TODO: just using the box height is insufficient
+        let box_height = props.bounding_box.size.height.saturating_as();
 
         // if point is outside the window, move the window
         self.vertical_offset -= if cursor_coordinates.y < 0 {
             cursor_coordinates.y
-        } else if cursor_coordinates.y + line_height > props.box_height {
-            cursor_coordinates.y + line_height - props.box_height
+        } else if cursor_coordinates.y + line_height > box_height {
+            cursor_coordinates.y + line_height - box_height
         } else {
             0
         };
 
         self.vertical_offset = self
             .vertical_offset
-            .max(props.box_height - props.text_height)
+            .max(box_height - props.text_height)
             .min(0);
 
         cursor.y += self.vertical_offset;

--- a/examples/interactive-editor.rs
+++ b/examples/interactive-editor.rs
@@ -324,12 +324,14 @@ impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<'_, C> {
                 }
             }
 
-            DesiredPosition::Offset(desired_offset) => {
+            DesiredPosition::Offset(mut desired_offset) => {
                 let current_offset = self.current_offset;
 
-                if text == None
-                    || (current_offset..current_offset + len.max(1)).contains(&desired_offset)
-                {
+                if text == None {
+                    desired_offset = current_offset;
+                }
+
+                if (current_offset..current_offset + len.max(1)).contains(&desired_offset) {
                     let chars_before = desired_offset - current_offset;
                     let pos = if chars_before == 0 {
                         // we want the end of the last character

--- a/examples/interactive-editor.rs
+++ b/examples/interactive-editor.rs
@@ -151,7 +151,7 @@ impl EditorInput {
     }
 
     pub fn move_cursor_to(&mut self, point: Point) {
-        self.cursor.desired_position = DesiredPosition::Coordinates(point);
+        self.cursor.desired_position = DesiredPosition::ScreenCoordinates(point);
     }
 }
 
@@ -161,7 +161,10 @@ enum DesiredPosition {
     OneLineDown(Point),
     EndOfText,
     Offset(usize),
+    /// Move the cursor to the desired text space coordinates
     Coordinates(Point),
+    /// Move the cursor to the desired screen space coordinates
+    ScreenCoordinates(Point),
 }
 
 impl DesiredPosition {
@@ -235,6 +238,10 @@ impl<'a, C: PixelColor> Plugin<'a, C> for EditorPlugin<'_, C> {
                         // As well as one line below last line (to jump down to end of last line)
                         .min(props.text_height),
                 ));
+            }
+            DesiredPosition::ScreenCoordinates(point) => {
+                // TODO transform to text space
+                self.desired_cursor_position = DesiredPosition::Coordinates(point)
             }
             _ => {}
         }

--- a/examples/interactive-editor.rs
+++ b/examples/interactive-editor.rs
@@ -1,6 +1,8 @@
 //! # Example: interactive-editor
 //!
 //! This example demonstrates how to use the plugins feature to implement an editable text box.
+//!
+//! Running this example requires enabling the "plugin" feature
 
 use az::SaturatingAs;
 use embedded_graphics::{

--- a/examples/interactive-editor.rs
+++ b/examples/interactive-editor.rs
@@ -1,9 +1,7 @@
-//! # Example: editor
+//! # Example: interactive-editor
 //!
-//! This example demonstrates a simple text "editor" that lets you type and delete characters.
-//!
-//! The demo uses the "Scrolling" vertical layout which is especially useful for
-//! editor type applications.
+//! This example demonstrates how to use the plugins feature to implement an editable text box.
+
 use az::SaturatingAs;
 use embedded_graphics::{
     geometry::AnchorPoint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ use embedded_graphics::{
 };
 use object_chain::{Chain, ChainElement, Link};
 pub use parser::{ChangeTextStyle, Token};
-pub use rendering::TextBoxProperties;
+pub use rendering::{cursor::Cursor, TextBoxProperties};
 
 /// A text box object.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,17 +247,14 @@ where
     where
         M: Plugin<'a, <S as TextRenderer>::Color>,
     {
-        let mut textbox = TextBox {
+        TextBox {
             text: self.text,
             bounds: self.bounds,
             character_style: self.character_style,
             style: self.style,
             vertical_offset: self.vertical_offset,
             plugin: PluginWrapper::new(Chain::new(plugin)),
-        };
-        textbox.style.height_mode.apply(&mut textbox);
-
-        textbox
+        }
     }
 }
 
@@ -275,17 +272,20 @@ where
     {
         let parent = self.plugin.inner.into_inner();
 
-        let mut textbox = TextBox {
+        TextBox {
             text: self.text,
             bounds: self.bounds,
             character_style: self.character_style,
             style: self.style,
             vertical_offset: self.vertical_offset,
             plugin: PluginWrapper::new(parent.plugin.append(plugin)),
-        };
-        textbox.style.height_mode.apply(&mut textbox);
+        }
+    }
 
-        textbox
+    /// Deconstruct the textbox and return the plugins.
+    #[inline]
+    pub fn take_plugins(self) -> P {
+        self.plugin.inner.into_inner().lookahead
     }
 }
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,4 +1,7 @@
-//! Plugin allow changing TextBox behaviour.
+//! Plugins allow changing TextBox behaviour.
+//!
+//! Note: Custom plugins are experimental. Ff you wish to implement custom plugins,
+//! you need to activate the `plugin` feature.
 
 use core::{
     cell::RefCell,
@@ -54,7 +57,10 @@ where
 /// Plugin marker trait.
 ///
 /// This trait is an implementation detail. Most likely you don't need to implement this.
-/// If you wish to implement a plugin, see [Plugin].
+#[cfg_attr(
+    feature = "plugin",
+    doc = "If you wish to implement a plugin, see [Plugin]."
+)]
 // TODO: remove this trait once Plugin is stabilized, then move Plugin here
 pub trait PluginMarker<'a, C: PixelColor>: Plugin<'a, C> {}
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -76,8 +76,8 @@ pub(crate) struct PluginInner<'a, M, C>
 where
     C: PixelColor,
 {
-    lookahead: M,
-    pub plugin: M,
+    pub(crate) lookahead: M,
+    pub(crate) plugin: M,
     state: ProcessingState,
     peeked_token: (usize, Option<Token<'a, C>>),
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -124,12 +124,6 @@ where
         this.lookahead = this.plugin.clone();
     }
 
-    pub fn end_of_text(&self) {
-        let mut this = self.inner.borrow_mut();
-
-        this.lookahead.end_of_text();
-    }
-
     pub fn set_state(&self, state: ProcessingState) {
         self.inner.borrow_mut().state = state;
     }
@@ -187,11 +181,17 @@ where
         this.plugin.on_start_render(cursor, &props);
     }
 
+    pub fn on_rendering_finished(&self) {
+        let mut this = self.inner.borrow_mut();
+
+        this.lookahead.on_rendering_finished();
+    }
+
     pub fn post_render<T, D>(
         &self,
         draw_target: &mut D,
         character_style: &T,
-        text: &str,
+        text: Option<&str>,
         bounds: Rectangle,
     ) -> Result<(), D::Error>
     where

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -124,6 +124,12 @@ where
         this.lookahead = this.plugin.clone();
     }
 
+    pub fn end_of_text(&self) {
+        let mut this = self.inner.borrow_mut();
+
+        this.lookahead.end_of_text();
+    }
+
     pub fn set_state(&self, state: ProcessingState) {
         self.inner.borrow_mut().state = state;
     }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -172,10 +172,11 @@ where
         this.peeked_token.0 = len;
         this.peeked_token.1.replace(token);
 
-        this.lookahead = this.plugin.clone();
+        // keeping this here messes up editor example with extremely long words.
+        // this.lookahead = this.plugin.clone();
     }
 
-    pub fn on_start_render<S: CharacterStyle>(
+    pub fn on_start_render<S: CharacterStyle + TextRenderer>(
         &self,
         cursor: &mut Cursor,
         props: TextBoxProperties<'_, S>,
@@ -183,7 +184,7 @@ where
         let mut this = self.inner.borrow_mut();
         this.peeked_token = (0, None);
 
-        this.plugin.on_start_render(cursor, props);
+        this.plugin.on_start_render(cursor, &props);
     }
 
     pub fn post_render<T, D>(

--- a/src/plugin/private.rs
+++ b/src/plugin/private.rs
@@ -26,6 +26,10 @@ where
     #[inline]
     fn new_line(&mut self) {}
 
+    /// Called after rendering has finished.
+    #[inline]
+    fn end_of_text(&mut self) {}
+
     /// Generate the next text token.
     #[inline]
     fn next_token(
@@ -82,6 +86,10 @@ where
         self.object.new_line();
     }
 
+    fn end_of_text(&mut self) {
+        self.object.end_of_text();
+    }
+
     fn next_token(
         &mut self,
         next_token: impl FnMut() -> Option<Token<'a, C>>,
@@ -127,6 +135,11 @@ where
     fn new_line(&mut self) {
         self.parent.new_line();
         self.object.new_line();
+    }
+
+    fn end_of_text(&mut self) {
+        self.parent.end_of_text();
+        self.object.end_of_text();
     }
 
     fn next_token(

--- a/src/plugin/private.rs
+++ b/src/plugin/private.rs
@@ -26,10 +26,6 @@ where
     #[inline]
     fn new_line(&mut self) {}
 
-    /// Called after rendering has finished.
-    #[inline]
-    fn end_of_text(&mut self) {}
-
     /// Generate the next text token.
     #[inline]
     fn next_token(
@@ -54,7 +50,7 @@ where
         &mut self,
         _draw_target: &mut D,
         _character_style: &T,
-        _text: &str,
+        _text: Option<&str>,
         _bounds: Rectangle,
     ) -> Result<(), D::Error>
     where
@@ -72,6 +68,10 @@ where
         _props: &TextBoxProperties<'_, S>,
     ) {
     }
+
+    /// Called after rendering has finished.
+    #[inline]
+    fn on_rendering_finished(&mut self) {}
 }
 
 impl<'a, C> Plugin<'a, C> for super::NoPlugin<C> where C: PixelColor {}
@@ -84,10 +84,6 @@ where
 {
     fn new_line(&mut self) {
         self.object.new_line();
-    }
-
-    fn end_of_text(&mut self) {
-        self.object.end_of_text();
     }
 
     fn next_token(
@@ -105,7 +101,7 @@ where
         &mut self,
         draw_target: &mut D,
         character_style: &T,
-        text: &str,
+        text: Option<&str>,
         bounds: Rectangle,
     ) -> Result<(), D::Error>
     where
@@ -123,6 +119,10 @@ where
     ) {
         self.object.on_start_render(cursor, &props)
     }
+
+    fn on_rendering_finished(&mut self) {
+        self.object.on_rendering_finished();
+    }
 }
 
 impl<'a, C, P, CE> Plugin<'a, C> for Link<P, CE>
@@ -135,11 +135,6 @@ where
     fn new_line(&mut self) {
         self.parent.new_line();
         self.object.new_line();
-    }
-
-    fn end_of_text(&mut self) {
-        self.parent.end_of_text();
-        self.object.end_of_text();
     }
 
     fn next_token(
@@ -161,7 +156,7 @@ where
         &mut self,
         draw_target: &mut D,
         character_style: &T,
-        text: &str,
+        text: Option<&str>,
         bounds: Rectangle,
     ) -> Result<(), D::Error>
     where
@@ -181,5 +176,10 @@ where
     ) {
         self.parent.on_start_render(cursor, &props);
         self.object.on_start_render(cursor, &props);
+    }
+
+    fn on_rendering_finished(&mut self) {
+        self.parent.on_rendering_finished();
+        self.object.on_rendering_finished();
     }
 }

--- a/src/plugin/private.rs
+++ b/src/plugin/private.rs
@@ -66,10 +66,10 @@ where
 
     /// Called before TextBox rendering is started.
     #[inline]
-    fn on_start_render<S: CharacterStyle>(
+    fn on_start_render<S: CharacterStyle + TextRenderer>(
         &mut self,
         _cursor: &mut Cursor,
-        _props: TextBoxProperties<'_, S>,
+        _props: &TextBoxProperties<'_, S>,
     ) {
     }
 }
@@ -116,12 +116,12 @@ where
             .post_render(draw_target, character_style, text, bounds)
     }
 
-    fn on_start_render<S: CharacterStyle>(
+    fn on_start_render<S: CharacterStyle + TextRenderer>(
         &mut self,
         cursor: &mut Cursor,
-        props: TextBoxProperties<'_, S>,
+        props: &TextBoxProperties<'_, S>,
     ) {
-        self.object.on_start_render(cursor, props)
+        self.object.on_start_render(cursor, &props)
     }
 }
 
@@ -174,12 +174,12 @@ where
             .post_render(draw_target, character_style, text, bounds)
     }
 
-    fn on_start_render<S: CharacterStyle>(
+    fn on_start_render<S: CharacterStyle + TextRenderer>(
         &mut self,
         cursor: &mut Cursor,
-        props: TextBoxProperties<'_, S>,
+        props: &TextBoxProperties<'_, S>,
     ) {
-        self.parent.on_start_render(cursor, props.clone());
-        self.object.on_start_render(cursor, props);
+        self.parent.on_start_render(cursor, &props);
+        self.object.on_start_render(cursor, &props);
     }
 }

--- a/src/plugin/tail.rs
+++ b/src/plugin/tail.rs
@@ -1,5 +1,6 @@
 //! Display the last lines of the text.
 
+use az::SaturatingAs;
 use embedded_graphics::{
     prelude::PixelColor,
     text::renderer::{CharacterStyle, TextRenderer},
@@ -20,8 +21,9 @@ impl<'a, C: PixelColor> Plugin<'a, C> for Tail {
         cursor: &mut Cursor,
         props: &TextBoxProperties<'_, S>,
     ) {
-        if props.text_height > props.box_height {
-            let offset = props.box_height - props.text_height;
+        let box_height = props.bounding_box.size.height.saturating_as();
+        if props.text_height > box_height {
+            let offset = box_height - props.text_height;
 
             cursor.y += offset
         }

--- a/src/plugin/tail.rs
+++ b/src/plugin/tail.rs
@@ -1,6 +1,9 @@
 //! Display the last lines of the text.
 
-use embedded_graphics::{prelude::PixelColor, text::renderer::CharacterStyle};
+use embedded_graphics::{
+    prelude::PixelColor,
+    text::renderer::{CharacterStyle, TextRenderer},
+};
 
 use crate::{plugin::Plugin, rendering::cursor::Cursor, TextBoxProperties};
 
@@ -12,10 +15,10 @@ use crate::{plugin::Plugin, rendering::cursor::Cursor, TextBoxProperties};
 pub struct Tail;
 
 impl<'a, C: PixelColor> Plugin<'a, C> for Tail {
-    fn on_start_render<S: CharacterStyle>(
+    fn on_start_render<S: CharacterStyle + TextRenderer>(
         &mut self,
         cursor: &mut Cursor,
-        props: TextBoxProperties<'_, S>,
+        props: &TextBoxProperties<'_, S>,
     ) {
         if props.text_height > props.box_height {
             let offset = props.box_height - props.text_height;

--- a/src/rendering/cursor.rs
+++ b/src/rendering/cursor.rs
@@ -107,7 +107,7 @@ impl Cursor {
     }
 
     #[must_use]
-    pub fn line(&self) -> LineCursor {
+    pub(crate) fn line(&self) -> LineCursor {
         LineCursor {
             start: Point::new(self.bounds.top_left.x, self.y),
             width: self.bounds.size.width,

--- a/src/rendering/cursor.rs
+++ b/src/rendering/cursor.rs
@@ -73,7 +73,7 @@ impl LineCursor {
 
 /// Internal structure that keeps track of position information while rendering a [`TextBox`].
 ///
-/// [`TextBox`]: ../../struct.TextBox.html
+/// [`TextBox`]: crate::TextBox
 #[derive(Copy, Clone, Debug)]
 pub struct Cursor {
     /// Current cursor position

--- a/src/rendering/line.rs
+++ b/src/rendering/line.rs
@@ -118,7 +118,7 @@ where
         let bounds = Rectangle::new(top_left, size);
 
         self.plugin
-            .post_render(self.display, self.style, st, bounds)?;
+            .post_render(self.display, self.style, Some(st), bounds)?;
 
         Ok(())
     }
@@ -134,7 +134,7 @@ where
         let bounds = Rectangle::new(top_left, size);
 
         self.plugin
-            .post_render(self.display, self.style, st, bounds)?;
+            .post_render(self.display, self.style, Some(st), bounds)?;
 
         Ok(())
     }
@@ -219,7 +219,7 @@ where
             next_state.plugin.post_render(
                 display,
                 &next_state.character_style,
-                "",
+                None,
                 Rectangle::new(
                     end_pos,
                     Size::new(0, next_state.character_style.line_height()),

--- a/src/rendering/line.rs
+++ b/src/rendering/line.rs
@@ -206,15 +206,18 @@ where
             ..
         } = self.state.clone();
 
-        let mut cloned_parser = parser.clone();
-        let measure_plugin = plugin.clone();
-        measure_plugin.set_state(ProcessingState::Measure);
-        let lm = style.measure_line(
-            &measure_plugin,
-            &character_style,
-            &mut cloned_parser,
-            self.cursor.line_width(),
-        );
+        let lm = {
+            // Ensure the clone lives for as short as possible.
+            let mut cloned_parser = parser.clone();
+            let measure_plugin = plugin.clone();
+            measure_plugin.set_state(ProcessingState::Measure);
+            style.measure_line(
+                &measure_plugin,
+                &character_style,
+                &mut cloned_parser,
+                self.cursor.line_width(),
+            )
+        };
 
         let (end_type, end_pos) = if display.bounding_box().size.height == 0 {
             // We're outside of the view. Use simpler render element handler and space config.

--- a/src/rendering/line_iter.rs
+++ b/src/rendering/line_iter.rs
@@ -237,11 +237,12 @@ where
             handler.whitespace(string, 0, 0)?;
             return Ok(());
         }
+        let signed_width = space_width.saturating_as();
         let draw_whitespace = (self.empty && self.render_leading_spaces())
             || self.render_trailing_spaces()
-            || self.next_word_fits(space_width.saturating_as(), handler);
+            || self.next_word_fits(signed_width, handler);
 
-        match self.move_cursor(space_width.saturating_cast()) {
+        match self.move_cursor(signed_width) {
             Ok(moved) => {
                 let spaces = if draw_whitespace { space_count } else { 0 };
                 handler.whitespace(string, spaces, moved.saturating_as())?;

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -41,8 +41,8 @@ pub struct TextBoxProperties<'a, S> {
     /// The height of the text.
     pub text_height: i32,
 
-    /// The height of the text box.
-    pub box_height: i32,
+    /// The bounds of the text box.
+    pub bounding_box: Rectangle,
 }
 
 impl<'a, F, M> Drawable for TextBox<'a, F, M>
@@ -90,7 +90,7 @@ where
             box_style: &self.style,
             char_style: &self.character_style,
             text_height,
-            box_height,
+            bounding_box: self.bounding_box(),
         };
 
         self.plugin.on_start_render(&mut cursor, props);

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -135,12 +135,13 @@ where
                     state.plugin.post_render(
                         &mut display,
                         &self.character_style,
-                        "",
+                        None,
                         Rectangle::new(
                             line_start,
                             Size::new(0, cursor.line_height().saturating_as()),
                         ),
                     )?;
+                    state.plugin.on_rendering_finished();
                     return Ok(self.text.get(consumed_bytes..).unwrap());
                 }
             } else {
@@ -151,7 +152,7 @@ where
 
             match state.end_type {
                 LineEndType::EndOfText => {
-                    state.plugin.end_of_text();
+                    state.plugin.on_rendering_finished();
                     break;
                 }
                 LineEndType::CarriageReturn => {}

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -150,7 +150,10 @@ where
             state = StyledLineRenderer::new(line_cursor, state).draw(&mut display)?;
 
             match state.end_type {
-                LineEndType::EndOfText => break,
+                LineEndType::EndOfText => {
+                    state.plugin.end_of_text();
+                    break;
+                }
                 LineEndType::CarriageReturn => {}
                 _ => {
                     cursor.new_line();

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -129,8 +129,7 @@
 //!  - Move the cursor backward `<n>` characters: `\x1b[<n>D`. This command will stop at the start
 //!    of line.
 //!
-//! [`TextBox`]: ../struct.TextBox.html
-//! [`TextBoxStyle`]: struct.TextBoxStyle.html
+//! [`TextBox`]: crate::TextBox
 //! [`TextBoxStyleBuilder`]: builder/struct.TextBoxStyleBuilder.html
 //! [`TextBoxStyleBuilder::new`]: builder/struct.TextBoxStyleBuilder.html#method.new
 //! [`TextBox::into_styled`]: ../struct.TextBox.html#method.into_styled


### PR DESCRIPTION
The goal of this PR is to improve the editor example to support vertical cursor movement.
 - [x] Words longer than a line are handled incorrectly. Might be an issue on line boundaries?
 - [x] There may or may not still be a small disagreement between the offsets with multiple empty lines.
 - [x] Click to move cursor
 - [x] Move displayed area if cursor moves out of view - coordinate based.
        Needs to track if cursor is at the end of line. Alternative is a one-frame delay.
 - [x] Move displayed area if cursor moves out of view - character offset based.
        Needs to specify that cursor coordinates are in "text space". Also, need to define "text space" vs "world space".
 - [x] Allow accessing plugins after drawing, remove `Rc` from plugin