### PR TITLE
Fix rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Unreleased
 
  * **breaking** [#133] `TextBoxStyle` and `TextBoxStyleBuilder` no longer implement the `Default` trait.
 
+## Fixed:
+
+ * [#140] Fixed an issue where, under certain circumstances no text was rendered.
+
 ## Removed:
 
  * [#134] `Scrolling` vertical alignment
@@ -23,6 +27,7 @@ Unreleased
 [#134]: https://github.com/embedded-graphics/embedded-text/pull/134
 [#135]: https://github.com/embedded-graphics/embedded-text/pull/135
 [#137]: https://github.com/embedded-graphics/embedded-text/pull/137
+[#140]: https://github.com/embedded-graphics/embedded-text/pull/140
 
 0.5.0-beta.2 (2021-07-10)
 ==========================

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -127,7 +127,7 @@ where
                 line_start + Point::new(0, display_range.start),
                 display_size,
             ));
-            if display_range.start == display_range.end {
+            if display_range.start >= display_range.end {
                 if anything_drawn {
                     let remaining_bytes = state.parser.as_str().len();
                     let consumed_bytes = self.text.len() - remaining_bytes;
@@ -170,7 +170,10 @@ where
 pub mod test {
     use embedded_graphics::{
         mock_display::MockDisplay,
-        mono_font::{ascii::FONT_6X9, MonoTextStyleBuilder},
+        mono_font::{
+            ascii::{FONT_6X10, FONT_6X9},
+            MonoTextStyleBuilder,
+        },
         pixelcolor::BinaryColor,
         prelude::*,
         primitives::Rectangle,
@@ -314,6 +317,42 @@ pub mod test {
             ".#..#..#.##...#.....#....#..#.",
             ".#..#..##.....#.....#....#..#.",
             ".#..#...###..###...###....##..",
+            "..............................",
+            "..............................",
+        ]);
+    }
+
+    #[test]
+    fn rendering_not_stopped_prematurely() {
+        let mut display = MockDisplay::new();
+
+        let character_style = MonoTextStyleBuilder::new()
+            .font(&FONT_6X10)
+            .text_color(BinaryColor::On)
+            .background_color(BinaryColor::Off)
+            .build();
+
+        TextBox::with_textbox_style(
+            "hello\nbuggy\nworld",
+            Rectangle::new(Point::zero(), size_for(&FONT_6X10, 5, 3)),
+            character_style,
+            TextBoxStyleBuilder::new()
+                .height_mode(HeightMode::Exact(VerticalOverdraw::Hidden))
+                .build(),
+        )
+        .set_vertical_offset(-20)
+        .draw(&mut display)
+        .unwrap();
+
+        display.assert_pattern(&[
+            "..............................",
+            "...................##.......#.",
+            "....................#.......#.",
+            "#...#..###..#.##....#....##.#.",
+            "#...#.#...#.##..#...#...#..##.",
+            "#.#.#.#...#.#.......#...#...#.",
+            "#.#.#.#...#.#.......#...#..##.",
+            ".#.#...###..#......###...##.#.",
             "..............................",
             "..............................",
         ]);


### PR DESCRIPTION
This PR fixes an issue where no text is rendered, if vertical offset was used to move text up by exactly (2+n)*line-height pixels.