### PR TITLE
Remove `From<Rgb888>` bounds in favor of `Default`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,6 @@ use crate::{
 };
 use embedded_graphics::{
     geometry::{Dimensions, Point},
-    pixelcolor::Rgb888,
     primitives::Rectangle,
     text::{
         renderer::{CharacterStyle, TextRenderer},
@@ -242,7 +241,6 @@ where
 
 impl<'a, S> TextBox<'a, S, NoPlugin<<S as TextRenderer>::Color>>
 where
-    <S as TextRenderer>::Color: From<Rgb888>,
     S: TextRenderer + CharacterStyle,
 {
     /// Creates a new `TextBox` instance with a given bounding `Rectangle`.
@@ -409,7 +407,6 @@ where
 
 impl<'a, S, P> TextBox<'a, S, P>
 where
-    <S as TextRenderer>::Color: From<Rgb888>,
     S: TextRenderer + CharacterStyle,
     P: Plugin<'a, <S as TextRenderer>::Color> + ChainElement,
 {
@@ -476,7 +473,6 @@ impl<'a, S, M> TextBox<'a, S, M>
 where
     S: TextRenderer,
     M: Plugin<'a, S::Color>,
-    S::Color: From<Rgb888>,
 {
     /// Sets the height of the [`TextBox`] to the height of the text.
     #[inline]

--- a/src/rendering/line_iter.rs
+++ b/src/rendering/line_iter.rs
@@ -11,7 +11,7 @@ use crate::{
     style::TextBoxStyle,
 };
 use az::SaturatingAs;
-use embedded_graphics::{pixelcolor::Rgb888, prelude::PixelColor};
+use embedded_graphics::prelude::PixelColor;
 
 /// Parser to break down a line into primitive elements used by measurement and rendering.
 #[derive(Debug)]
@@ -72,7 +72,7 @@ pub trait ElementHandler {
 
 impl<'a, 'b, M, C> LineElementParser<'a, 'b, M, C>
 where
-    C: PixelColor + From<Rgb888>,
+    C: PixelColor,
     M: Plugin<'a, C>,
 {
     /// Creates a new element parser.
@@ -464,7 +464,7 @@ pub(crate) mod test {
     use embedded_graphics::{
         geometry::{Point, Size},
         mono_font::{ascii::FONT_6X9, MonoTextStyle},
-        pixelcolor::BinaryColor,
+        pixelcolor::{BinaryColor, Rgb888},
         primitives::Rectangle,
         text::{renderer::TextRenderer, LineHeight},
     };

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -18,7 +18,6 @@ use crate::{
 use az::SaturatingAs;
 use embedded_graphics::{
     draw_target::{DrawTarget, DrawTargetExt},
-    pixelcolor::Rgb888,
     prelude::{Dimensions, Point, Size},
     primitives::Rectangle,
     text::renderer::{CharacterStyle, TextRenderer},
@@ -47,8 +46,8 @@ pub struct TextBoxProperties<'a, S> {
 impl<'a, F, M> Drawable for TextBox<'a, F, M>
 where
     F: TextRenderer<Color = <F as CharacterStyle>::Color> + CharacterStyle,
-    <F as CharacterStyle>::Color: From<Rgb888>,
     M: Plugin<'a, <F as TextRenderer>::Color> + Plugin<'a, <F as CharacterStyle>::Color>,
+    <F as CharacterStyle>::Color: Default,
 {
     type Color = <F as CharacterStyle>::Color;
     type Output = &'a str;

--- a/src/style/height_mode.rs
+++ b/src/style/height_mode.rs
@@ -7,7 +7,7 @@ use crate::{
     plugin::PluginMarker as Plugin, rendering::cursor::Cursor, style::VerticalOverdraw, TextBox,
 };
 use core::ops::Range;
-use embedded_graphics::{geometry::Dimensions, pixelcolor::Rgb888, text::renderer::TextRenderer};
+use embedded_graphics::{geometry::Dimensions, text::renderer::TextRenderer};
 
 /// Specifies how the [`TextBox`]'s height should be adjusted.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -184,7 +184,6 @@ impl HeightMode {
     where
         F: TextRenderer,
         M: Plugin<'a, F::Color>,
-        F::Color: From<Rgb888>,
     {
         match self {
             HeightMode::Exact(_) => {}

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -194,10 +194,7 @@ use crate::{
     },
     utils::str_width,
 };
-use embedded_graphics::{
-    pixelcolor::Rgb888,
-    text::{renderer::TextRenderer, LineHeight},
-};
+use embedded_graphics::text::{renderer::TextRenderer, LineHeight};
 
 pub use self::{
     builder::TextBoxStyleBuilder, height_mode::HeightMode, vertical_overdraw::VerticalOverdraw,
@@ -431,7 +428,6 @@ impl TextBoxStyle {
     where
         S: TextRenderer,
         M: Plugin<'a, S::Color>,
-        S::Color: From<Rgb888>,
     {
         let cursor = LineCursor::new(max_line_width, self.tab_size.into_pixels(character_style));
 
@@ -503,7 +499,6 @@ impl TextBoxStyle {
     pub fn measure_text_height<S>(&self, character_style: &S, text: &str, max_width: u32) -> u32
     where
         S: TextRenderer,
-        S::Color: From<Rgb888>,
     {
         let plugin = PluginWrapper::new(NoPlugin::new());
         self.measure_text_height_impl(plugin, character_style, text, max_width)
@@ -519,7 +514,6 @@ impl TextBoxStyle {
     where
         S: TextRenderer,
         M: Plugin<'a, S::Color>,
-        S::Color: From<Rgb888>,
     {
         let mut parser = Parser::parse(text);
         let base_line_height = character_style.line_height();


### PR DESCRIPTION
I was looking at what it would take to add color support to [`embedded-menu`](https://crates.io/crates/embedded-menu) and realized there were `From<Rgb888>` generic bounds that seemed to propagate in various spots. Digging in, it seemed that this all was traced back to the `ChangeTextStyle`'s `Reset` variant having a hard-coded `Rgb888` value it would set the text color to.

This PR switches the `From<Rgb888>` bounds to use `Default`, instead - aligning more with behavior expected by a "Reset" and also enabling a developer to specify, through implementation of the `Default` trait, their desired reset color. 