### PR TITLE
Fix breaking long words with wide utf8 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.7.2 (2024-05-03)
+==================
+
+ - [#168] Fix breaking long words with wide utf8 characters 
+
+[#168]: https://github.com/embedded-graphics/embedded-text/pull/168
+
+
 0.7.1 (2024-04-29)
 ==================
 

--- a/src/rendering/line_iter.rs
+++ b/src/rendering/line_iter.rs
@@ -363,7 +363,7 @@ where
 
                     if !remainder.is_empty() {
                         // Consume what was printed.
-                        self.plugin.consume_partial(word.len());
+                        self.plugin.consume_partial(word.chars().count());
                         return Ok(LineEndType::LineBreak);
                     }
                 }

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -552,4 +552,46 @@ pub mod test {
             ".......................................          ",
         ]);
     }
+
+    #[test]
+    fn correctly_breaks_long_words_with_wide_utf8_characters() {
+        let mut display = MockDisplay::new();
+        let character_style = MonoTextStyleBuilder::new()
+            .font(&FONT_6X10)
+            .text_color(BinaryColor::On)
+            .background_color(BinaryColor::Off)
+            .build();
+
+        TextBox::with_textbox_style(
+            "広広広", // MonoText replaces unrecognized characters with "?"
+            Rectangle::new(Point::zero(), size_for(&FONT_6X10, 2, 2)),
+            character_style,
+            TextBoxStyleBuilder::new().build(),
+        )
+        .draw(&mut display)
+        .unwrap();
+
+        display.assert_pattern(&[
+            "............",
+            ".###...###..",
+            "#...#.#...#.",
+            "...#.....#..",
+            "..#.....#...",
+            "..#.....#...",
+            "............",
+            "..#.....#...",
+            "............",
+            "............",
+            "......      ",
+            ".###..      ",
+            "#...#.      ",
+            "...#..      ",
+            "..#...      ",
+            "..#...      ",
+            "......      ",
+            "..#...      ",
+            "......      ",
+            "......      ",
+        ]);
+    }
 }


### PR DESCRIPTION
@bugadani hello, it's me again 😁

Just noticed another issue when breaking words that contain chars longer than 1 byte. 

`LineElementParser` consumes more characters than needed because `str.len()` actually measures in bytes, not in characters.

I would say it was quite fun and rewarding to find and fix this!